### PR TITLE
Small tweak to `entity.name.class` grammar

### DIFF
--- a/syntaxes/supercollider.tmLanguage.json
+++ b/syntaxes/supercollider.tmLanguage.json
@@ -113,7 +113,7 @@
               "name": "entity.name.class.supercollider"
             }
           },
-          "match": "^([A-Z]{1}[a-zA-Z0-9_]*)[^a-zA-Z0-9_]"
+          "match": "([A-Z]{1}[a-zA-Z0-9_]*)[^a-zA-Z0-9_]"
         },
 
         {


### PR DESCRIPTION
Very small one liner (1 character, really) had a huge impact on the syntax highlighting accuracy.

| Before | After |
|------- | ----- |
|<img width="430" alt="Screen Shot 2022-09-01 at 10 40 48 PM" src="https://user-images.githubusercontent.com/22264820/188047760-c73324f9-7908-481f-a3eb-ff1b907ee6b1.png">| <img width="437" alt="Screen Shot 2022-09-01 at 10 29 26 PM" src="https://user-images.githubusercontent.com/22264820/188046320-56221af7-339a-47ef-8af8-54968bf5b404.png"> | 
