### PR TITLE
Add commands from SCIDE's `Server` menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,11 +69,59 @@
             {
                 "command": "supercollider.evaluateSelection",
                 "key": "ctrl+return",
+                "mac": "cmd+enter",
+                "when": "editorHasSelection && resourceExtname == .scd"
+            },
+            {
+                "command": "supercollider.evaluateRegion",
+                "key": "ctrl+return",
+                "mac": "cmd+enter",
+                "when": "!editorHasSelection && resourceExtname == .scd"
+            },
+            {
+                "command": "supercollider.evaluateLine",
+                "key": "shift+enter",
                 "when": "resourceExtname == .scd"
             },
             {
-                "command": "supercollider.killTerminal",
-                "key": "ctrl+."
+                "command": "supercollider.cmdPeriod",
+                "key": "ctrl+.",
+                "mac": "cmd+."
+            },
+            {
+                "command": "supercollider.searchHelp",
+                "key": "ctrl+d",
+                "mac": "cmd+d"
+            },
+            {
+                "command": "supercollider.showServerMeter",
+                "key": "ctrl+m",
+                "mac": "cmd+m"
+            },
+            {
+                "command": "supercollider.showScope",
+                "key": "shift+ctrl+m",
+                "mac": "shift+cmd+m"
+            },
+            {
+                "command": "supercollider.showFreqscope",
+                "key": "alt+ctrl+m",
+                "mac": "alt+cmd+m"
+            },
+            {
+                "command": "supercollider.dumpNodeTree",
+                "key": "ctrl+t",
+                "mac": "cmd+t"
+            },
+            {
+                "command": "supercollider.dumpNodeTreeWithControls",
+                "key": "shift+ctrl+t",
+                "mac": "shift+cmd+t"
+            },
+            {
+                "command": "supercollider.showNodeTree",
+                "key": "alt+ctrl+t",
+                "mac": "alt+cmd+t"
             }
         ],
         "commands": [
@@ -105,6 +153,51 @@
             {
                 "command": "supercollider.showServerWindow",
                 "title": "Show server window",
+                "category": "SuperCollider"
+            },
+            {
+                "command": "supercollider.showServerMeter",
+                "title": "Show server meter",
+                "category": "SuperCollider"
+            },
+            {
+                "command": "supercollider.showScope",
+                "title": "Show scope",
+                "category": "SuperCollider"
+            },
+            {
+                "command": "supercollider.showFreqscope",
+                "title": "Show freqscope",
+                "category": "SuperCollider"
+            },
+            {
+                "command": "supercollider.dumpNodeTree",
+                "title": "Dump node tree",
+                "category": "SuperCollider"
+            },
+            {
+                "command": "supercollider.dumpNodeTreeWithControls",
+                "title": "Dump node tree with controls",
+                "category": "SuperCollider"
+            },
+            {
+                "command": "supercollider.showNodeTree",
+                "title": "Show node tree",
+                "category": "SuperCollider"
+            },
+            {
+                "command": "supercollider.startRecording",
+                "title": "Start recording",
+                "category": "SuperCollider"
+            },
+            {
+                "command": "supercollider.pauseRecording",
+                "title": "Pause recording",
+                "category": "SuperCollider"
+            },
+            {
+                "command": "supercollider.stopRecording",
+                "title": "Stop recording",
                 "category": "SuperCollider"
             },
             {

--- a/package.json
+++ b/package.json
@@ -87,41 +87,6 @@
                 "command": "supercollider.cmdPeriod",
                 "key": "ctrl+.",
                 "mac": "cmd+."
-            },
-            {
-                "command": "supercollider.searchHelp",
-                "key": "ctrl+d",
-                "mac": "cmd+d"
-            },
-            {
-                "command": "supercollider.showServerMeter",
-                "key": "ctrl+m",
-                "mac": "cmd+m"
-            },
-            {
-                "command": "supercollider.showScope",
-                "key": "shift+ctrl+m",
-                "mac": "shift+cmd+m"
-            },
-            {
-                "command": "supercollider.showFreqscope",
-                "key": "alt+ctrl+m",
-                "mac": "alt+cmd+m"
-            },
-            {
-                "command": "supercollider.dumpNodeTree",
-                "key": "ctrl+t",
-                "mac": "cmd+t"
-            },
-            {
-                "command": "supercollider.dumpNodeTreeWithControls",
-                "key": "shift+ctrl+t",
-                "mac": "shift+cmd+t"
-            },
-            {
-                "command": "supercollider.showNodeTree",
-                "key": "alt+ctrl+t",
-                "mac": "alt+cmd+t"
             }
         ],
         "commands": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,7 +46,53 @@ export async function activate(context)
     context.subscriptions.push(vscode.commands.registerCommand(
         'supercollider.cmdPeriod',
         async () => {
-            supercolliderContext.executeCommand('supercollider.internal.showServerWindow')}));
+            supercolliderContext.executeCommand('supercollider.internal.cmdPeriod')}));
+
+    context.subscriptions.push(vscode.commands.registerCommand(
+        'supercollider.showServerMeter',
+        async () => {
+            supercolliderContext.executeCommand('supercollider.internal.showServerMeter')}));
+
+    context.subscriptions.push(vscode.commands.registerCommand(
+        'supercollider.showScope',
+        async () => {
+            supercolliderContext.executeCommand('supercollider.internal.showScope')}));
+
+    context.subscriptions.push(vscode.commands.registerCommand(
+        'supercollider.showFreqscope',
+        async () => {
+            supercolliderContext.executeCommand('supercollider.internal.showFreqscope')}));
+
+    context.subscriptions.push(vscode.commands.registerCommand(
+        'supercollider.dumpNodeTree',
+        async () => {
+            supercolliderContext.executeCommand('supercollider.internal.dumpNodeTree')}));
+
+    context.subscriptions.push(vscode.commands.registerCommand(
+        'supercollider.dumpNodeTreeWithControls',
+        async () => {
+            supercolliderContext.executeCommand('supercollider.internal.dumpNodeTreeWithControls')}));
+
+    context.subscriptions.push(vscode.commands.registerCommand(
+        'supercollider.showNodeTree',
+        async () => {
+            supercolliderContext.executeCommand('supercollider.internal.showNodeTree')}));
+
+    context.subscriptions.push(vscode.commands.registerCommand(
+        'supercollider.startRecording',
+        async () => {
+            supercolliderContext.executeCommand('supercollider.internal.startRecording')}));
+
+    context.subscriptions.push(vscode.commands.registerCommand(
+        'supercollider.pauseRecording',
+        async () => {
+            supercolliderContext.executeCommand('supercollider.internal.pauseRecording')}));
+
+    context.subscriptions.push(vscode.commands.registerCommand(
+        'supercollider.stopRecording',
+        async () => {
+            supercolliderContext.executeCommand('supercollider.internal.stopRecording')}));
+    
 
     help.activate(supercolliderContext);
 


### PR DESCRIPTION
Registers commands and key commands from the Server menu in SCIDE to push feature parity with SCIDE. Also adds key commands for `supercollider.evaluateSelection`, `supercollider.evaluateRegion`, `supercollider.evaluateLine`, and `supercollider.searchHelp`.

Added commands are as follows:

- `supercollider.cmdPeriod`
- `supercollider.showServerMeter`
- `supercollider.showScope`
- `supercollider.showFreqscope`
- `supercollider.dumpNodeTree`
- `supercollider.dumpNodeTreeWithControls`
- `supercollider.showNodeTree`
- `supercollider.startRecording`
- `supercollider.pauseRecording`
- `supercollider.stopRecording`

Requires more commands to be added to the `ExecuteCommandProvider` in LanguageServer.quark. I opened a PR for that [here](https://github.com/scztt/LanguageServer.quark/pull/11).