### PR TITLE
Add code evaluation settings for blink and post evaluate message

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,3 +3,5 @@ BasedOnStyle: Microsoft
 ColumnLimit: 0
 AlignOperands: AlignAfterOperator
 AlignConsecutiveAssignments: AcrossEmptyLinesAndComments
+IndentWidth: 4   
+TabWidth: 4   

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.formatOnSave": true,
+  "[typescript]": {
+    "editor.defaultFormatter": "xaver.clang-format"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -76,6 +76,11 @@
                         "type": "string",
                         "default": "error",
                         "description": "Log level for sclang language server {info, debug, warning, error, critical, all}"
+                    },
+                    "supercollider.codeEvaluation.blinkDuration": {
+                        "type": "number",
+                        "default": 600,
+                        "description": "The amount of time to highlight the executed code"
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -81,6 +81,11 @@
                         "type": "number",
                         "default": 600,
                         "description": "The amount of time to highlight the executed code"
+                    },
+                    "supercollider.codeEvaluation.showMessage": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Show a message toast after code execution"
                     }
                 }
             }

--- a/src/commands/evaluate.ts
+++ b/src/commands/evaluate.ts
@@ -268,22 +268,30 @@ async function evaluateString(client: vscodelc.BaseLanguageClient, document: vsc
     });
 
     result.then((result) => {
+        const prefix = '⇒ ';
+
         if (result.result !== undefined)
         {
-            const prefix = '⇒ ';
-            vscode.window.showInformationMessage(prefix + result.result);
+            if (context.codeEvaluationSettings.showMessage)
+            {
+                vscode.window.showInformationMessage(prefix + result.result);
+            }
             finishFunc(result.result, false);
         }
         else if (result.compileError !== undefined)
         {
-            const prefix = '⇏ ';
-            vscode.window.showErrorMessage(prefix + result.compileError);
+            if (context.codeEvaluationSettings.showMessage)
+            {
+                vscode.window.showErrorMessage(prefix + result.compileError);
+            }
             finishFunc(result.compileError, true);
         }
         else if (result.error !== undefined)
         {
-            const prefix = '⇏ ';
-            vscode.window.showErrorMessage(prefix + result.error);
+            if (context.codeEvaluationSettings.showMessage)
+            {
+                vscode.window.showErrorMessage(prefix + result.error);
+            }
             finishFunc(result.error, true);
         }
     });
@@ -297,7 +305,7 @@ export class EvaluateSelectionFeature extends TextDocumentFeature<EvaluateSelect
 {
     _context: SuperColliderContext;
 
-    constructor(client, context: SuperColliderContext)
+    constructor(client: vscodelc.BaseLanguageClient, context: SuperColliderContext)
     {
         super(client, EvaluateSelectionRequest.type);
         this._context = context;
@@ -323,7 +331,7 @@ export class EvaluateSelectionFeature extends TextDocumentFeature<EvaluateSelect
     registerLanguageProvider(): [ vscode.Disposable, EvaluateSelectionProvider ]
     {
         const provider: EvaluateSelectionProvider = {
-            evaluateString : (document: vscode.TextDocument, range: vscode.Selection, context: SuperColliderContext) => {
+            evaluateString : (document: vscode.TextDocument, range: vscode.Selection) => {
                 const client                   = this._client;
 
                 const provideEvaluateSelection = (document: vscode.TextDocument, range: vscode.Selection, context: SuperColliderContext) => {

--- a/src/commands/evaluate.ts
+++ b/src/commands/evaluate.ts
@@ -38,8 +38,8 @@ const errorDecorator   = vscode.window.createTextEditorDecorationType({
     outline : 'border-left-width: 1px',
     isWholeLine : true,
   });
-let evaluateCount       = 0;
-const decoratorTimeout = 5000;
+let evaluateCount      = 0;
+const decoratorTimeout = 600;
 
 // Start and end execution actions
 function onEndEvaluate(textEditor: TextEditor, range: Range, responseText: string, isError: boolean)
@@ -84,7 +84,7 @@ function onStartEvaluate(textEditor: TextEditor, range: Range)
     }, decoratorTimeout);
 
     return (text: string, isError: boolean) => {
-        if (evaluateCount == currentEvaluateCount)
+        if (evaluateCount != currentEvaluateCount)
         {
             onEndEvaluate(textEditor, range, text, isError)
         }

--- a/src/context.ts
+++ b/src/context.ts
@@ -33,24 +33,29 @@ export class SuperColliderContext implements Disposable
     sclangProcess: cp.ChildProcess;
     lspTokenPath: string;
     outputChannel: vscode.OutputChannel;
+    codeEvaluationSettings: {
+        blinkDuration: number;
+    };
 
     processOptions()
     {
-        const configuration               = workspace.getConfiguration()
+        const configuration               = workspace.getConfiguration();
 
-        const sclangPath                  = configuration.get<string>('supercollider.sclang.cmd')
-        const sclangArgs                  = configuration.get<Array<string>>('supercollider.sclang.args')
-        const sclangEnv                   = configuration.get<Object>('supercollider.sclang.environment')
-        const sclangConfYaml              = configuration.get<string>('supercollider.sclang.confYaml')
+        const sclangPath                  = configuration.get<string>('supercollider.sclang.cmd');
+        const sclangArgs                  = configuration.get<Array<string>>('supercollider.sclang.args');
+        const sclangEnv                   = configuration.get<Object>('supercollider.sclang.environment');
+        const sclangConfYaml              = configuration.get<string>('supercollider.sclang.confYaml');
 
-        const readPort                    = configuration.get<number>('supercollider.sclang.lspReadPort')
-        const writePort                   = configuration.get<number>('supercollider.sclang.lspWritePort')
+        const readPort                    = configuration.get<number>('supercollider.sclang.lspReadPort');
+        const writePort                   = configuration.get<number>('supercollider.sclang.lspWritePort');
+
+        this.codeEvaluationSettings       = configuration.get('supercollider.codeEvaluation')
 
         let env                           = process.env;
         env['SCLANG_LSP_ENABLE']          = '1';
         env['SCLANG_LSP_SERVERPORT']      = readPort.toString();
         env['SCLANG_LSP_CLIENTPORT']      = writePort.toString();
-        env['SCLANG_LSP_LOGLEVEL']        = configuration.get<string>('supercollider.languageServerLogLevel')
+        env['SCLANG_LSP_LOGLEVEL']        = configuration.get<string>('supercollider.languageServerLogLevel');
 
         let spawnOptions: cp.SpawnOptions = {
             env : Object.assign(env, sclangEnv)
@@ -113,7 +118,7 @@ export class SuperColliderContext implements Disposable
         let sclangProcess = this.sclangProcess = this.createProcess();
 
         const serverOptions: ServerOptions     = function() {
-                // @TODO what if terminal launch fails?
+            // @TODO what if terminal launch fails?
 
             const configuration = workspace.getConfiguration()
             const readPort      = configuration.get<number>('supercollider.sclang.lspReadPort')
@@ -135,10 +140,10 @@ export class SuperColliderContext implements Disposable
                             res(streamInfo);
                         }
                         outputChannel.append(string);
-                    });
+                        });
 
                     sclangProcess.on('exit', (code, signal) => { sclangProcess = null; });
-                });
+                    });
             });
         };
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -35,6 +35,7 @@ export class SuperColliderContext implements Disposable
     outputChannel: vscode.OutputChannel;
     codeEvaluationSettings: {
         blinkDuration: number;
+        showMessage : boolean;
     };
 
     processOptions()


### PR DESCRIPTION
The evaluation background decorator had a bug where instead of applying the timeout value, it just flashed. I also shortened the timeout to 600ms, which I _think_ is the SCIDE default. This timeout value could probably be a setting someday.