### PR TITLE
Check if client exists during cleanup (crashes in activate)

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -93,7 +93,7 @@ export class SuperColliderContext implements Disposable
     {
         this.activated = false;
 
-        if (this.client.isRunning())
+        if (this.client?.isRunning())
         {
             await this.client.stop();
         }


### PR DESCRIPTION
The extension crashes on activate. Running on mbp m1 max, ventura 13.5. Stack trace:

```
rejected promise not handled within 1 second: TypeError: Cannot read properties of undefined (reading 'isRunning')
extensionHostProcess.js:131
stack trace: TypeError: Cannot read properties of undefined (reading 'isRunning')
	at SuperColliderContext.<anonymous> (/Users/regisverdin/ext-code/vscode-supercollider/out/context.js:79:29)
	at Generator.next (<anonymous>)
	at /Users/regisverdin/ext-code/vscode-supercollider/out/context.js:8:71
	at new Promise (<anonymous>)
	at __awaiter (/Users/regisverdin/ext-code/vscode-supercollider/out/context.js:4:12)
	at SuperColliderContext.cleanup (/Users/regisverdin/ext-code/vscode-supercollider/out/context.js:77:16)
	at SuperColliderContext.<anonymous> (/Users/regisverdin/ext-code/vscode-supercollider/out/context.js:97:18)
	at Generator.next (<anonymous>)
	at /Users/regisverdin/ext-code/vscode-supercollider/out/context.js:8:71
	at new Promise (<anonymous>)
	at __awaiter (/Users/regisverdin/ext-code/vscode-supercollider/out/context.js:4:12)
	at SuperColliderContext.activate (/Users/regisverdin/ext-code/vscode-supercollider/out/context.js:95:16)
	at /Users/regisverdin/ext-code/vscode-supercollider/out/extension.js:31:44
	at Generator.next (<anonymous>)
	at /Users/regisverdin/ext-code/vscode-supercollider/out/extension.js:8:71
	at new Promise (<anonymous>)
	at __awaiter (/Users/regisverdin/ext-code/vscode-supercollider/out/extension.js:4:12)
	at doActivate (/Users/regisverdin/ext-code/vscode-supercollider/out/extension.js:29:34)
	at /Users/regisverdin/ext-code/vscode-supercollider/out/extension.js:121:9
	at Generator.next (<anonymous>)
	at /Users/regisverdin/ext-code/vscode-supercollider/out/extension.js:8:71
	at new Promise (<anonymous>)
	at __awaiter (/Users/regisverdin/ext-code/vscode-supercollider/out/extension.js:4:12)
	at activate (/Users/regisverdin/ext-code/vscode-supercollider/out/extension.js:24:12)
	at q.ib (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:136:13170)
	at q.hb (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:136:12896)
	at /Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:136:11037
	at async v.n (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:124:6205)
	at async v.m (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:124:6168)
	at async v.l (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:124:5625)
```

I'm not sure why other people haven't run into this, it doesn't look like a race condition to me. But I also don't use javascript often, so I may have missed something.