### PR TITLE
Give info when updateLanguageServer fails.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -78,10 +78,11 @@ export async function activate(context: vscode.ExtensionContext)
 
             await new Promise((res, rej) => {
                 sclangProcess.on('exit', () => {
-                    if (sclangProcess.exitCode == 1) {
+                    if (sclangProcess.exitCode === 0) {
+                        res(true);
+                    } else {
                         rej(`Failed to install/update LanguageServer quark. Run command to see error: \n\n${(sclangProcess.spawnargs).join(' ')}`);
                     }
-                    res(true);
                 });
             })
         }));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,6 +41,10 @@ export async function activate(context: vscode.ExtensionContext)
             const sclangPath     = await getSclangPath();
             const sclangConfYaml = configuration.get<string>('supercollider.sclang.confYaml', defaults.userConfigPath());
 
+            if (sclangConfYaml != '' && !fs.existsSync(sclangConfYaml)) {
+                throw new Error("Sclang config file does not exist. Please check the 'supercollider.sclang.confYaml' path in your settings.");
+            }
+
             const tempFilePath = await new Promise<string>((res, err) => {
                                                                fs.mkdtemp(
                                                                    path.join(os.tmpdir(), 'vscode-supercollider'),
@@ -55,9 +59,14 @@ export async function activate(context: vscode.ExtensionContext)
                                                                            fs.writeFile(
                                                                                finalPath,
                                                                                `
-                                                                               try { Quarks.install("https://github.com/scztt/LanguageServer.quark") };
-                                                                               try { Quarks.update("https://github.com/scztt/LanguageServer.quark") };
-                                                                               0.exit;
+                                                                               var exitCode = 0;
+                                                                               try { Quarks.install("https://github.com/scztt/LanguageServer.quark");
+                                                                                     Quarks.update("https://github.com/scztt/LanguageServer.quark");
+                                                                               } { |err|
+                                                                                     postln(err.errorString);
+                                                                                     exitCode = 1;
+                                                                               };
+                                                                               exitCode.exit;
                                                                                `,
                                                                                null,
                                                                                () => {res(finalPath)});
@@ -67,8 +76,11 @@ export async function activate(context: vscode.ExtensionContext)
             const args         = [ '-l', sclangConfYaml, tempFilePath ];
             let sclangProcess  = cp.spawn(sclangPath, args);
 
-            await new Promise((res) => {
+            await new Promise((res, rej) => {
                 sclangProcess.on('exit', () => {
+                    if (sclangProcess.exitCode == 1) {
+                        rej(`Failed to install/update LanguageServer quark. Run command to see error: \n\n${(sclangProcess.spawnargs).join(' ')}`);
+                    }
                     res(true);
                 });
             })


### PR DESCRIPTION
I had a lot of trouble getting the extension to work because I added an invalid config yaml path to my settings. It had "Application\ Support" instead of "Application Support", which caused it to fail silently.

This PR is to make updateLanguageServer fail in a more informative way, especially with these two cases:

1. Where the user adds a bad config yaml path.
2. Where something else goes wrong in the child process running the LanguageServer install/update, and the user wants to know what happened.

For 2, I just display the command for the user to run, as a quick fix. It would probably be cleaner to capture stdout from sclang and log it in vscode though.