### PR TITLE
Added server status information to the status bar.

### DIFF
--- a/src/ServerStatusBar.ts
+++ b/src/ServerStatusBar.ts
@@ -1,0 +1,80 @@
+import * as vscode from "vscode";
+
+export type ServerStatusBarData = {
+  name?: string;
+  running: boolean;
+  unresponsive: boolean;
+  avgCPU: number;
+  peakCPU: number;
+  numUGens: number;
+  numSynths: number;
+  numGroups: number;
+  numSynthDefs: number;
+};
+
+export class ServerStatusBar {
+  private statusBarItem: vscode.StatusBarItem;
+
+  constructor() {
+    this.statusBarItem = vscode.window.createStatusBarItem(
+      vscode.StatusBarAlignment.Right,
+      100
+    );
+    this.statusBarItem.name = "Supercollider Server Status";
+    this.statusBarItem.show();
+  }
+
+  getStatusBarItem() {
+    return this.statusBarItem;
+  }
+
+  updateStatusBar(data: ServerStatusBarData) {
+    let {
+      running,
+      unresponsive,
+      avgCPU,
+      peakCPU,
+      numUGens,
+      numSynths,
+      numGroups,
+      numSynthDefs,
+    } = data;
+    if (!running) {
+      unresponsive = false;
+      avgCPU = 0;
+      peakCPU = 0;
+      numUGens = 0;
+      numSynths = 0;
+      numGroups = 0;
+      numSynthDefs = 0;
+    }
+    const percentFormatter = Intl.NumberFormat(undefined, {
+      maximumFractionDigits: 2,
+      minimumFractionDigits: 2
+    });
+
+    const icon = unresponsive
+      ? `$(warning)`
+      : running
+      ? `$(play)`
+      : `$(primitive-square)`;
+
+    this.statusBarItem.command = unresponsive
+      ? "supercollider.internal.rebootServer"
+      : running
+      ? "supercollider.internal.killAllServers"
+      : "supercollider.internal.bootServer";
+
+    this.statusBarItem.tooltip = unresponsive
+      ? "Server is unresponsive. Click to restart."
+      : running
+      ? "Server is running. Click to stop."
+      : "Server is not running. Click to start.";
+
+    const avgCPUFormatted = percentFormatter.format(avgCPU);
+
+    const peakCPUFormatted = percentFormatter.format(peakCPU);
+
+    this.statusBarItem.text = `${icon} ${avgCPUFormatted}% ${peakCPUFormatted}% ${numUGens}u ${numSynths}s ${numGroups}g ${numSynthDefs}d`;
+  }
+}


### PR DESCRIPTION
This PR will add a status bar to the vscode extension. This status bar will show the server status of the Supercollider server. 

With a click on the status bar it is possible to start and stop the server. In case the server is unresponsive a click on the status bar will restart the server.

The following values are show in the status bar:

1. Icon of the server status (play, stop, warning)
2. Average CPU usage
3. Peak CPU usage
4. Number of UGens
5. Number of Synths
6. Number of Groups
7. Number of SynthDefs.

Here is a image:

![334572447-ef6bf205-0f48-4bd2-b721-69c28364062c](https://github.com/scztt/vscode-supercollider/assets/176220/9492caae-d0f8-4132-8c25-8b2762fc01b0)

This is a follow up PR to a PR in the language server quark (https://github.com/scztt/LanguageServer.quark/pull/26)

