### PR TITLE
fix sclang restart not working on some systems

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -175,7 +175,10 @@ export class SuperColliderContext implements Disposable {
     };
 
     dispose() {
-        this.serverPorts.dispose();
+        if (this.serverPorts) {
+            this.serverPorts.dispose();
+        }
+
         return this.cleanup()
     }
 


### PR DESCRIPTION
Fixes #65 .

Don't really have time to test super thoroughly, but this fixes the "restart sclang" on my system and doesn't seem to break other stuff. The issue seemed to be that this.serverPorts was undefined and calling dispose on it caused issues. 

I think maybe because the language server was picking an arbitrary free port rather than suggesting a specific port (I see "[LANGUAGESERVER.QUARK] suggestedServerPortRange: nil" in the logs which is always how it's worked for me)? Maybe that's why it was undefined? I'm guessing depending on your setup, one might define a specific port to use and wouldn't run into this issue in that situation.

FYI with this fix, I see a message in the output after restarting "[Error - 7:58:26 PM] Stopping server timed out" after it restarts, but I haven't noticed any actual problem as a result of that (and even checking task manager, I can see that it's not doing something awful like spawning more and more sclang / scysnth instances with each restart).